### PR TITLE
Lab deposit tasks

### DIFF
--- a/hive.js
+++ b/hive.js
@@ -67,10 +67,17 @@ let Hive = {
 			if (!_.has(Game, ["creeps", c])) {
 				if (Memory.creeps[c]["task"] != null) {
 					let task = Memory.creeps[c]["task"];
-					if (_.has(Memory, ["rooms", task.room, "tasks", "running", task.key]))
-						delete Memory["rooms"][task.room]["tasks"]["running"][task.key][c];
-				}
-				delete Memory.creeps[c];
+					if (_.get(task, "type") == "industry") {
+						if (_.has(Memory, ["rooms", task.room, "industry", "tasks", "running", task.key]))
+							delete Memory["rooms"][task.room]["industry"]["tasks"]["running"][task.key][c];
+
+					} else {
+						if (_.has(Memory, ["rooms", task.room, "tasks", "running", task.key]))
+							delete Memory["rooms"][task.room]["tasks"]["running"][task.key][c];
+					}
+				task.creeps += 1;
+                }
+		delete Memory.creeps[c];
 		}});
 
 		_.each(Object.keys(Memory.rooms), r => { 

--- a/sites.industry.js
+++ b/sites.industry.js
@@ -464,7 +464,10 @@ module.exports = {
 									key: `industry:withdraw-${mineral}-${lab.id}`, room: rmColony,
 									type: "industry", subtype: "withdraw", resource: mineral,
 									id: lab.id, pos: lab.pos, timer: 60, creeps: 10, priority: 2 });
-
+								Tasks.addTask(rmColony, {
+									key: `industry:deposit-${mineral}-${lab.id}`, room: rmColony,
+									type: "industry", subtype: "deposit", resource: mineral,
+									id: storage.id, pos: storage.pos, timer: 60, creeps: 10, priority: 2 });
 							}
 					});
 

--- a/sites.industry.js
+++ b/sites.industry.js
@@ -370,6 +370,8 @@ module.exports = {
 					break;
 
 				case "empty":
+				    storage = Game.rooms[rmColony].storage;
+				    if (storage == null) break;
 					_.forEach(listing["labs"], l => {
 						lab = Game.getObjectById(l);
 						if (lab.mineralAmount > 0) {
@@ -377,6 +379,10 @@ module.exports = {
 								key: `industry:withdraw-${lab.mineralType}-${lab.id}`, room: rmColony,
 								type: "industry", subtype: "withdraw", resource: lab.mineralType,
 								id: lab.id, pos: lab.pos, timer: 60, creeps: 10, priority: 2 });
+							Tasks.addTask(rmColony, {
+								key: `industry:deposit-${lab.mineralType}-${lab.id}`, room: rmColony,
+								type: "industry", subtype: "deposit", resource: lab.mineralType,
+								id: storage.id, pos:storage.pos, timer: 60, creeps: 10, priority: 2 });
 						}
 					});
 					break;
@@ -453,12 +459,13 @@ module.exports = {
 								key: `industry:withdraw-${lab.mineralType}-${lab.id}`, room: rmColony,
 								type: "industry", subtype: "withdraw", resource: lab.mineralType,
 								id: lab.id, pos: lab.pos, timer: 60, creeps: 10, priority: 2 });
-						} else if (lab.mineralAmount > lab.mineralCapacity * 0.2) {
-							Tasks.addTask(rmColony, {
-								key: `industry:withdraw-${mineral}-${lab.id}`, room: rmColony,
-								type: "industry", subtype: "withdraw", resource: mineral,
-								id: lab.id, pos: lab.pos, timer: 60, creeps: 10, priority: 2 });
-						}
+							} else if (lab.mineralAmount > lab.mineralCapacity * 0.2) {
+								Tasks.addTask(rmColony, {
+									key: `industry:withdraw-${mineral}-${lab.id}`, room: rmColony,
+									type: "industry", subtype: "withdraw", resource: mineral,
+									id: lab.id, pos: lab.pos, timer: 60, creeps: 10, priority: 2 });
+
+							}
 					});
 
 					break;


### PR DESCRIPTION
Added deposit tasks for labtasks (unsure if this was to be handled automatically, but as-is couriers would attempt to empty minerals from reactors but would then remain idle due to no tasks to deposit those minerals and no carry capacity to do anything else)

Adjusted creep memory cleanup, increase task.creeps on creep death.

This is a partial fix for Issue #19, industry tasks still appear to never get deleted.